### PR TITLE
Sprint 11 responsibilty changes

### DIFF
--- a/Gallery/Scenes/Auth/AuthViewController.swift
+++ b/Gallery/Scenes/Auth/AuthViewController.swift
@@ -2,19 +2,13 @@ import UIKit
 import ProgressHUD
 
 protocol AuthViewControllerDelegate: AnyObject {
-    
-    func didAuthenticate()
-    
+    func authViewController(_ vc: AuthViewController, didAuthenticateWithCode code: String)
 }
 
 
 final class AuthViewController: UIViewController {
     
     private let showWebViewSegueID = "ShowWebView"
-    
-    let getTokenService = OAuth2Service()
-    var tokenStorage = OAuth2TokenStorage()
-    
     weak var delegate: AuthViewControllerDelegate?
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -32,24 +26,8 @@ final class AuthViewController: UIViewController {
 extension AuthViewController: WebViewViewControllerDelegate {
     
     func webViewViewController(_ vc: WebViewViewController, didAuthenticateWithCode code: String) {
-                
-        UIBlockingProgressHUD.show()
         
-        getTokenService.fetchAuthToken(code: code) { [weak self] result in
-            guard let self else { return }
-            
-            DispatchQueue.main.async {
-                
-                switch result {
-                case .success(let token):
-                    self.tokenStorage.token = token
-                    self.delegate?.didAuthenticate()
-                case .failure(let error):
-                    print("ERROR: \(error.localizedDescription)")
-                }
-                
-            }
-        }
+        delegate?.authViewController(self, didAuthenticateWithCode: code)
     }
     
     func webViewViewControllerDidCancel(_ vc: WebViewViewController) {

--- a/Gallery/Scenes/Auth/AuthViewController.swift
+++ b/Gallery/Scenes/Auth/AuthViewController.swift
@@ -38,7 +38,6 @@ extension AuthViewController: WebViewViewControllerDelegate {
         getTokenService.fetchAuthToken(code: code) { [weak self] result in
             guard let self else { return }
             
-            
             DispatchQueue.main.async {
                 
                 switch result {

--- a/Gallery/Scenes/Profile/ProfileViewController.swift
+++ b/Gallery/Scenes/Profile/ProfileViewController.swift
@@ -11,23 +11,23 @@ class ProfileViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        profileService.fetchProfile(token!) { [weak self] result in
-            guard let self else { return }
-            
-            DispatchQueue.main.async {
-                
-                switch result {
-                case.success(let result):
-                    self.nameLabel.text = result.name
-                    self.loginNameLabel.text = result.loginName
-                    self.descriptionLabel.text = result.bio
-                case.failure(let error):
-                    print("ERROR: \(error.localizedDescription)")
-                }
-            }
-        }
+        updateProfile()
     }
+}
+
+extension ProfileViewController {
+    
+    private func updateProfile() {
+        
+        let profileService = ProfileService.shared
+        let profile = profileService.profile
+        
+        nameLabel.text = profile?.username
+        loginNameLabel.text = profile?.loginName
+        descriptionLabel.text = profile?.bio
+        
+    }
+    
 }
 
 

--- a/Gallery/Scenes/Profile/ProfileViewController.swift
+++ b/Gallery/Scenes/Profile/ProfileViewController.swift
@@ -6,13 +6,13 @@ class ProfileViewController: UIViewController {
     @IBOutlet var loginNameLabel: UILabel!
     @IBOutlet var descriptionLabel: UILabel!
     
-    let prof = ProfileService()
+    let profileService = ProfileService()
     let token = OAuth2TokenStorage().token
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        prof.fetchProfile(token!) { [weak self] result in
+        profileService.fetchProfile(token!) { [weak self] result in
             guard let self else { return }
             
             DispatchQueue.main.async {

--- a/Gallery/Scenes/SplashViewController/SplashViewController.swift
+++ b/Gallery/Scenes/SplashViewController/SplashViewController.swift
@@ -13,6 +13,7 @@ final class SplashViewController: UIViewController {
     private let tabBarStoryboardID = "TabBarViewController"
     
     private let getTokenService = OAuth2Service()
+    private var tokenStorage = OAuth2TokenStorage()
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -81,10 +82,34 @@ extension SplashViewController {
 }
 
 extension SplashViewController: AuthViewControllerDelegate {
- 
+    
+    func authViewController(_ vc: AuthViewController, didAuthenticateWithCode code: String) {
+                
+        UIBlockingProgressHUD.show()
+        
+        getTokenService.fetchAuthToken(code: code) { [weak self] result in
+            guard let self else { return }
+            
+            DispatchQueue.main.async {
+                
+                switch result {
+                case .success(let token):
+                    self.tokenStorage.token = token
+                    self.didAuthenticate()
+                case .failure(let error):
+                    print("ERROR: \(error.localizedDescription)")
+                }
+                
+            }
+        }
+    }
     func didAuthenticate() {
         UIBlockingProgressHUD.dismiss()
         switchToTabBarController()
     }
         
 }
+
+//
+
+

--- a/Gallery/Scenes/SplashViewController/SplashViewController.swift
+++ b/Gallery/Scenes/SplashViewController/SplashViewController.swift
@@ -127,8 +127,9 @@ extension SplashViewController {
                 
                 switch result {
                 
-                case.success:
+                case.success(let profileResult):
                     UIBlockingProgressHUD.dismiss()
+                    self.updateProfile(with: profileResult)
                     self.switchToTabBarController()
                     
                 case.failure(let error):
@@ -138,4 +139,13 @@ extension SplashViewController {
             }
         }
     }
+}
+
+extension SplashViewController {
+    
+    func updateProfile(with data: Profile) {
+        
+    }
+
+    
 }

--- a/Gallery/Services/OAuth2Service.swift
+++ b/Gallery/Services/OAuth2Service.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 enum FetchTokenError: Error {
     case noResponse
     case invalidResponse

--- a/Gallery/Services/ProfileService.swift
+++ b/Gallery/Services/ProfileService.swift
@@ -8,6 +8,8 @@ enum FetchProfileError: Error {
 
 final class ProfileService {
     
+    static let shared = ProfileService() // Singleton
+    
     let urlSession = URLSession.shared
     private var task: URLSessionTask?
 

--- a/Gallery/Services/ProfileService.swift
+++ b/Gallery/Services/ProfileService.swift
@@ -4,11 +4,14 @@ enum FetchProfileError: Error {
     case dataError
     case decodingData
     case invalidResponse
+    case noProfileData
 }
 
 final class ProfileService {
     
     static let shared = ProfileService() // Singleton
+    
+    private(set) var profile: Profile?
     
     let urlSession = URLSession.shared
     private var task: URLSessionTask?
@@ -54,6 +57,7 @@ final class ProfileService {
         guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
             DispatchQueue.main.async {
                 completion(.failure(FetchProfileError.invalidResponse))
+                return
             }
             return
         }
@@ -72,6 +76,7 @@ final class ProfileService {
             decodeData(data, completion: completion)
         } else {
             completion(.failure(FetchProfileError.dataError))
+            return
         }
     }
     
@@ -81,15 +86,23 @@ final class ProfileService {
     ///   - completion: A callback that will be called with the result of decoding the data
     
     private func decodeData(_ data: Data, completion: @escaping (Result<Profile, Error>) -> Void) {
+        
         let decoder = JSONDecoder()
+        
         do {
             let profileResult = try decoder.decode(ProfileResult.self, from: data)
-            let profile = Profile(result: profileResult)
+            profile = Profile(result: profileResult)
+            
+            guard let profile else {
+                completion(.failure(FetchProfileError.noProfileData))
+                return
+            }
             completion(.success(profile))
         } catch {
-            print("Decoding failed: \(error)")
             completion(.failure(FetchProfileError.decodingData))
+            return
         }
+        
     }
     
 }


### PR DESCRIPTION
- Took responsibility (fetchAuthToken and fetchProfile) from AuthViewController to SplashVC. 
- Added singleton to save profile data and access it from ProfileVC.